### PR TITLE
Bump version to 1.0.0

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -21,7 +21,7 @@
 # Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
 # or visit www.oracle.com if you need additional information or have any
 # questions.
-version=1.0ea
+version=1.0.0
 arch64=-arch x86_64
 arch32=-arch i386
 archppc=-arch ppc

--- a/build.xml
+++ b/build.xml
@@ -69,7 +69,7 @@ questions.
             <isset property="env.JAVA_HOME"/>
         </condition>
 
-        <exec executable="${cc}">
+        <exec executable="${cc}" failonerror="true">
             <arg line="${arch64} ${arch32}"/>
             <arg value="-I"/>
             <arg value="${javahome}/include"/>


### PR DESCRIPTION
In preparation for upload to the artifactory.  94db80d should also fail the build on non-supported platforms (10.9 for instance).
