### PR TITLE
Merge appbundler mainline and activate Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
-os: osx
-
-language: java
+language: objective-c
 
 install: brew install ant
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: java
+
+sudo: false
+
+addons:
+  apt_packages:
+    - ant
+    
+script: ant clean compile package

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ os: osx
 
 language: java
 
-sudo: false
+install: brew install ant
 
-addons:
-  apt_packages:
-    - ant
-    
 script: ant clean compile package

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+os: osx
+
 language: java
 
 sudo: false

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Example:
         classname="com.oracle.appbundler.AppBundlerTask"/>
 
       <bundleapp 
+          jvmrequired="1.7"
           classpathref="runclasspathref"
           outputdirectory="${dist}"
           name="${bundle.name}"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ with the following changes:
   the OSX special folders and whether the application is running in the
   sandbox (see below).
 - Allows overriding of passed JVM options by the bundled app itself via java.util.Preferences **(contributed by Hendrik Schreiber)**
+- Allows writing arbitrary key-value pairs to `Info.plist` via `plistentry`
 
 These are the environment variables passed to the JVM:
 
@@ -71,6 +72,9 @@ Example:
             role="editor"
             isPackage="true">
           </bundledocument>
+
+          <!-- Define custom key-value pairs in Info.plist -->
+          <plistentry key="ABCCustomKey" value="foobar"/>
 
           <!-- Workaround as com.apple.mrj.application.apple.menu.about.name property may no longer work -->
           <option value="-Xdock:name=${bundle.name}"/>

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ These are the environment variables passed to the JVM:
 - `SandboxEnabled` (the String `true` or `false`)
 
 
-Example:
+Example 1:
 
     <target name="bundle">
       <taskdef name="bundleapp" 
@@ -34,7 +34,6 @@ Example:
         classname="com.oracle.appbundler.AppBundlerTask"/>
 
       <bundleapp 
-          jvmrequired="1.7"
           classpathref="runclasspathref"
           outputdirectory="${dist}"
           name="${bundle.name}"
@@ -85,3 +84,52 @@ Example:
           <option value="-Xmx1024M" name="Xmx"/>
       </bundleapp>
     </target>
+
+Example 2, use installed Java but require Java 8 (or later):
+
+    <target name="bundle">
+      <taskdef name="bundleapp" 
+        classpath="appbundler-1.0ea.jar"
+        classname="com.oracle.appbundler.AppBundlerTask"/>
+      <bundleapp 
+          jvmrequired="1.8"
+          classpathref="runclasspathref"
+          outputdirectory="${dist}"
+          name="${bundle.name}"
+          displayname="${bundle.displayname}"
+          executableName="MyApp"
+          identifier="com.company.product"
+          shortversion="${version.public}"
+          version="${version.internal}"
+          icon="${icons.path}/${bundle.icns}"
+          mainclassname="Main"
+          copyright="2012 Your Company"
+          applicationCategory="public.app-category.finance">
+      </bundleapp>
+    </target>
+
+Example 2, use installed Java but require Java 8 (or later) JRE and not a JDK:
+
+    <target name="bundle">
+      <taskdef name="bundleapp" 
+        classpath="appbundler-1.0ea.jar"
+        classname="com.oracle.appbundler.AppBundlerTask"/>
+      <bundleapp 
+          jvmrequired="1.8"
+          jrepreferred="true"
+          classpathref="runclasspathref"
+          outputdirectory="${dist}"
+          name="${bundle.name}"
+          displayname="${bundle.displayname}"
+          executableName="MyApp"
+          identifier="com.company.product"
+          shortversion="${version.public}"
+          version="${version.internal}"
+          icon="${icons.path}/${bundle.icns}"
+          mainclassname="Main"
+          copyright="2012 Your Company"
+          applicationCategory="public.app-category.finance">
+      </bundleapp>
+    </target>
+
+

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ Example:
             isPackage="true">
           </bundledocument>
 
-          <!-- Workaround since the icon parameter for bundleapp doesn't work -->
-          <option value="-Xdock:icon=Contents/Resources/${bundle.icon}"/>
+          <!-- Workaround as com.apple.mrj.application.apple.menu.about.name property may no longer work -->
+          <option value="-Xdock:name=${bundle.name}"/>
 
           <option value="-Dapple.laf.useScreenMenuBar=true"/>
           <option value="-Dcom.apple.macos.use-file-dialog-packages=true"/>

--- a/appbundler/native/main.m
+++ b/appbundler/native/main.m
@@ -119,7 +119,7 @@ int launch(char *commandName, int progargc, char *progargv[]) {
     if (workingDir != nil) {
         workingDir = [workingDir stringByReplacingOccurrencesOfString:@APP_ROOT_PREFIX withString:[mainBundle bundlePath]];
     } else {
-        workingDir = NSHomeDirectory();
+        workingDir = [[NSFileManager defaultManager] currentDirectoryPath];
     }
     if (isDebugging) {
     	NSLog(@"Working Directory: '%@'", convertRelativeFilePath(workingDir));

--- a/appbundler/native/main.m
+++ b/appbundler/native/main.m
@@ -333,14 +333,16 @@ int launch(char *commandName, int progargc, char *progargv[]) {
         argv[i++] = strdup([argument UTF8String]);
     }
 
-	for (int ctr = 0; ctr < progargc; ctr++) {
+	int ctr = 0;
+	for (ctr = 0; ctr < progargc; ctr++) {
 		argv[i++] = progargv[ctr];
 	}
     
     // Print the full command line for debugging purposes...
     if (isDebugging) {
         NSLog(@"Command line passed to application:");
-        for( int j=0; j<i; j++) {
+        int j=0;
+        for(j=0; j<i; j++) {
             NSLog(@"Arg %d: '%s'", j, argv[j]);
         }
     }

--- a/appbundler/native/main.m
+++ b/appbundler/native/main.m
@@ -47,6 +47,7 @@
 #define UNSPECIFIED_ERROR "An unknown error occurred."
 
 #define APP_ROOT_PREFIX "$APP_ROOT"
+#define JVM_RUNTIME "$JVM_RUNTIME"
 
 #define JRE_JAVA "/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/bin/java"
 #define JRE_DYLIB "/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home/lib/jli/libjli.dylib"
@@ -358,6 +359,7 @@ int launch(char *commandName, int progargc, char *progargv[]) {
 
     for (NSString *option in options) {
         option = [option stringByReplacingOccurrencesOfString:@APP_ROOT_PREFIX withString:[mainBundle bundlePath]];
+        option = [option stringByReplacingOccurrencesOfString:@JVM_RUNTIME withString:runtimePath];
         argv[i++] = strdup([option UTF8String]);
     }
 

--- a/appbundler/native/main.m
+++ b/appbundler/native/main.m
@@ -144,7 +144,9 @@ int launch(char *commandName, int progargc, char *progargv[]) {
 
     if (runtime != nil)
     {
-        javaDylib = [runtimePath stringByAppendingPathComponent:@"Contents/Home/jre/lib/jli/libjli.dylib"];
+        NSString *dylibRelPath = [runtime hasSuffix:@".jdk"] ? @"Contents/Home/jre/lib/jli/libjli.dylib"
+            : @"Contents/Home/lib/jli/libjli.dylib";
+        javaDylib = [runtimePath stringByAppendingPathComponent:dylibRelPath];
     }
     else
     {

--- a/appbundler/res/de.lproj/Localizable.strings
+++ b/appbundler/res/de.lproj/Localizable.strings
@@ -1,4 +1,5 @@
 "JRELoadError" = "Kann die Java Laufzeitumgebung nicht laden.";
+"JRExLoadError" = "Kann die Java %d Laufzeitumgebung nicht laden.";
 "MainClassNameRequired" = "Hauptklassenname ist erforderlich.";
 "JavaDirectoryNotFound" = "Kann den Inhalt des Java-Ordners nicht lesen.";
 "BundlePathContainsColon" = "Kann nicht vom einem Ordner aus starten, der \"/\" in seinem Namen enthält.";

--- a/appbundler/res/de.lproj/Localizable.strings
+++ b/appbundler/res/de.lproj/Localizable.strings
@@ -1,5 +1,7 @@
-"JRELoadError" = "Kann die Java Laufzeitumgebung nicht laden.";
-"JRExLoadError" = "Kann die Java %d Laufzeitumgebung nicht laden.";
+"JRELoadError" = "Die Java Laufzeitumgebung konnte nicht geladen werden.";
+"JRExLoadError" = "Die Java %d Laufzeitumgebung konnte nicht geladen werden.";
+"JRExLoadFullError" = "Diese Anwendung benötigt die Java %d Laufzeitumgebung oder höher auf Ihrem Computer installiert sein. Bitte installieren Sie die neueste Version von Java von www.java.com und erneut versuchen.";
+"JDKxLoadFullError" = "Diese Anwendung benötigt die Java %d Laufzeitumgebung oder höher auf Ihrem Computer installiert sein. Bitte installieren Sie die neueste JDK von Oracle.com und erneut versuchen.";
 "MainClassNameRequired" = "Hauptklassenname ist erforderlich.";
-"JavaDirectoryNotFound" = "Kann den Inhalt des Java-Ordners nicht lesen.";
+"JavaDirectoryNotFound" = "Das Java Verzeichnis ist nicht vorhanden.";
 "BundlePathContainsColon" = "Kann nicht vom einem Ordner aus starten, der \"/\" in seinem Namen enthält.";

--- a/appbundler/res/en.lproj/Localizable.strings
+++ b/appbundler/res/en.lproj/Localizable.strings
@@ -1,5 +1,7 @@
 "JRELoadError" = "Unable to load Java Runtime Environment.";
 "JRExLoadError" = "Unable to load a Java %d Runtime Environment.";
+"JRExLoadFullError" = "This application requires that Java %d or later be installed on your computer. Please download and install the latest version of Java from www.java.com and try again.";
+"JDKxLoadFullError" = "This application requires that a Java %d JDK or later be installed on your computer. Please download and install the latest Java JDK from Oracle.com and try again.";
 "MainClassNameRequired" = "Main class name is required.";
 "JavaDirectoryNotFound" = "Unable to enumerate Java directory contents.";
 "BundlePathContainsColon" = "Cannot launch from folder that contains a \"/\" in its name.";

--- a/appbundler/res/en.lproj/Localizable.strings
+++ b/appbundler/res/en.lproj/Localizable.strings
@@ -1,4 +1,5 @@
-"JRELoadError" = "Unable to load Java Runtime Environment.";
-"MainClassNameRequired" = "Main class name is required.";
-"JavaDirectoryNotFound" = "Unable to enumerate Java directory contents.";
-"BundlePathContainsColon" = "Cannot launch from folder that contains a \"/\" in its name.";
+"JRELoadError" = "Kann die Java Laufzeitumgebung nicht laden.";
+"JRExLoadError" = "Kann die Java %d Laufzeitumgebung nicht laden.";
+"MainClassNameRequired" = "Hauptklassenname ist erforderlich.";
+"JavaDirectoryNotFound" = "Kann den Inhalt des Java-Ordners nicht lesen.";
+"BundlePathContainsColon" = "Kann nicht vom einem Ordner aus starten, der \"/\" in seinem Namen enthält.";

--- a/appbundler/res/en.lproj/Localizable.strings
+++ b/appbundler/res/en.lproj/Localizable.strings
@@ -1,5 +1,5 @@
-"JRELoadError" = "Kann die Java Laufzeitumgebung nicht laden.";
-"JRExLoadError" = "Kann die Java %d Laufzeitumgebung nicht laden.";
-"MainClassNameRequired" = "Hauptklassenname ist erforderlich.";
-"JavaDirectoryNotFound" = "Kann den Inhalt des Java-Ordners nicht lesen.";
-"BundlePathContainsColon" = "Kann nicht vom einem Ordner aus starten, der \"/\" in seinem Namen enthält.";
+"JRELoadError" = "Unable to load Java Runtime Environment.";
+"JRExLoadError" = "Unable to load a Java %d Runtime Environment.";
+"MainClassNameRequired" = "Main class name is required.";
+"JavaDirectoryNotFound" = "Unable to enumerate Java directory contents.";
+"BundlePathContainsColon" = "Cannot launch from folder that contains a \"/\" in its name.";

--- a/appbundler/res/fr.lproj/Localizable.strings
+++ b/appbundler/res/fr.lproj/Localizable.strings
@@ -1,0 +1,6 @@
+"JRELoadError" = "Impossible d'utiliser un environnement Java.";
+"JRExLoadError" = "Impossible d'utiliser un environnement Java %d.";
+"JRExLoadFullError" = "Ce logiciel nécessite que Java %d ou plus récent être installés sur votre ordinateur. S'il vous plaît télécharger et installer la dernière version de Java à partir de www.java.com et essayez à nouveau.";
+"MainClassNameRequired" = "Principal nom de classe est nécessaire.";
+"JavaDirectoryNotFound" = "Impossible d'énumérer répertoire Java contenu.";
+"BundlePathContainsColon" = "Pas de commencer à partir d'un dossier qui contient un \"/\" dans son nom.";

--- a/appbundler/res/fr.lproj/Localizable.strings
+++ b/appbundler/res/fr.lproj/Localizable.strings
@@ -1,6 +1,7 @@
 "JRELoadError" = "Impossible d'utiliser un environnement Java.";
 "JRExLoadError" = "Impossible d'utiliser un environnement Java %d.";
 "JRExLoadFullError" = "Ce logiciel nécessite que Java %d ou plus récent être installés sur votre ordinateur. S'il vous plaît télécharger et installer la dernière version de Java à partir de www.java.com et essayez à nouveau.";
+"JDKxLoadFullError" = "Ce logiciel nécessite que Java %d JDK ou plus récent être installés sur votre ordinateur. S'il vous plaît télécharger et installer le JDK plus récente de Oracle.com et essayez à nouveau.";
 "MainClassNameRequired" = "Principal nom de classe est nécessaire.";
 "JavaDirectoryNotFound" = "Impossible d'énumérer répertoire Java contenu.";
 "BundlePathContainsColon" = "Pas de commencer à partir d'un dossier qui contient un \"/\" dans son nom.";

--- a/appbundler/src/com/oracle/appbundler/AppBundlerTask.java
+++ b/appbundler/src/com/oracle/appbundler/AppBundlerTask.java
@@ -97,6 +97,7 @@ public class AppBundlerTask extends Task {
     private ArrayList<String> architectures = new ArrayList<>();
     private ArrayList<String> registeredProtocols = new ArrayList<>();
     private ArrayList<BundleDocument> bundleDocuments = new ArrayList<>();
+    private ArrayList<PlistEntry> plistEntries = new ArrayList<>();
     
     private Reference classPathRef;
     private ArrayList<String> plistClassPaths = new ArrayList<>();
@@ -224,6 +225,17 @@ public class AppBundlerTask extends Task {
     
     public void addConfiguredBundleDocument(BundleDocument document) {
         this.bundleDocuments.add(document);
+    }
+
+    public void addConfiguredPlistEntry(PlistEntry plistEntry) {
+        if (plistEntry.getKey() == null) {
+            throw new BuildException("Name is required.");
+        }
+        if (plistEntry.getValue() == null) {
+            throw new BuildException("Value is required.");
+        }
+
+        this.plistEntries.add(plistEntry);
     }
 
     public void addConfiguredOption(Option option) throws BuildException {
@@ -728,6 +740,12 @@ public class AppBundlerTask extends Task {
 
             xout.writeEndElement();
             xout.writeCharacters("\n");
+
+            // Write arbitrary key-value pairs
+            for (PlistEntry item : plistEntries) {
+                writeKey(xout, item.getKey());
+                writeString(xout, item.getValue());
+            }
 
             // End root dictionary
             xout.writeEndElement();

--- a/appbundler/src/com/oracle/appbundler/AppBundlerTask.java
+++ b/appbundler/src/com/oracle/appbundler/AppBundlerTask.java
@@ -658,7 +658,7 @@ public class AppBundlerTask extends Task {
 
                     File ifile = bundleDocument.getIconFile();
                     
-                    if (file != null) {
+                    if (ifile != null) {
                         writeString(xout, ifile.getName());
                     }
                     else {

--- a/appbundler/src/com/oracle/appbundler/AppBundlerTask.java
+++ b/appbundler/src/com/oracle/appbundler/AppBundlerTask.java
@@ -667,7 +667,7 @@ public class AppBundlerTask extends Task {
 
                     File ifile = bundleDocument.getIconFile();
                     
-                    if (file != null) {
+                    if (ifile != null) {
                         writeString(xout, ifile.getName());
                     }
                     else {

--- a/appbundler/src/com/oracle/appbundler/AppBundlerTask.java
+++ b/appbundler/src/com/oracle/appbundler/AppBundlerTask.java
@@ -76,7 +76,8 @@ public class AppBundlerTask extends Task {
     private String copyright = "";
     private String privileged = null;
     private String workingDirectory = null;
-    private String minimumSystemVersion = null;    
+    private String minimumSystemVersion = null;  
+    private String jvmRequired = "1.7";  
 
     private String applicationCategory = null;
 
@@ -160,6 +161,10 @@ public class AppBundlerTask extends Task {
         this.workingDirectory = workingDirectory;
     }
     
+    public void setJVMRequired(String v){
+        this.jvmRequired = v;
+    }
+        
     public void setMinimumSystemVersion(String v){
         this.minimumSystemVersion = v;
     }
@@ -614,6 +619,10 @@ public class AppBundlerTask extends Task {
             // Write runtime
             if (runtime != null) {
                 writeProperty(xout, "JVMRuntime", runtime.getDir().getParentFile().getParentFile().getName());
+            }
+            
+            if ( jvmRequired != null ) {
+                writeProperty(xout, "JVMVersion", jvmRequired);
             }
             
             if ( privileged != null ) {

--- a/appbundler/src/com/oracle/appbundler/AppBundlerTask.java
+++ b/appbundler/src/com/oracle/appbundler/AppBundlerTask.java
@@ -42,6 +42,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.StringTokenizer;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -98,6 +99,7 @@ public class AppBundlerTask extends Task {
     private ArrayList<BundleDocument> bundleDocuments = new ArrayList<>();
     
     private Reference classPathRef;
+    private ArrayList<String> plistClassPaths = new ArrayList<>();
 
     private static final String EXECUTABLE_NAME = "JavaAppLauncher";
     private static final String DEFAULT_ICON_NAME = "GenericApp.icns";
@@ -219,6 +221,13 @@ public class AppBundlerTask extends Task {
              
     public void setClasspathRef(Reference ref) {   
         this.classPathRef = ref;                                         
+    }
+
+    public void setPlistClassPaths(String plistClassPaths) {
+        StringTokenizer tok = new StringTokenizer(plistClassPaths, ", ", false);
+        while (tok.hasMoreTokens()) {
+            this.plistClassPaths.add(tok.nextToken());
+        }
     }
 
     public void addConfiguredClassPath(FileSet classPath) {
@@ -635,6 +644,18 @@ public class AppBundlerTask extends Task {
 
             // Write main class name
             writeProperty(xout, "JVMMainClassName", mainClassName);
+
+            // Write classpaths in plist, if specified
+            if (!plistClassPaths.isEmpty()) {
+                writeKey(xout, "JVMClassPath");
+                xout.writeStartElement(ARRAY_TAG);
+                xout.writeCharacters("\n");
+                for (String cp : plistClassPaths) {
+                    writeString(xout, cp);
+                }
+                xout.writeEndElement();
+                xout.writeCharacters("\n");
+            }
 
             // Write whether launcher be verbose with debug msgs
             if (isDebug) {

--- a/appbundler/src/com/oracle/appbundler/PlistEntry.java
+++ b/appbundler/src/com/oracle/appbundler/PlistEntry.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015, Oracle and/or its affiliates. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.appbundler;
+
+public class PlistEntry extends Option {
+
+    public void setKey(String key) {
+        setName(key);
+    }
+
+    public String getKey() {
+        return getName();
+    }
+}

--- a/appbundler/src/com/oracle/appbundler/Runtime.java
+++ b/appbundler/src/com/oracle/appbundler/Runtime.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2012, Oracle and/or its affiliates. All rights reserved.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.appbundler;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.tools.ant.DirectoryScanner;
+import org.apache.tools.ant.types.FileSet;
+
+public class Runtime extends FileSet {
+
+    /* Override to provide canonical path so that runtime can be specified
+     * via a version-agnostic path (relative link, e.g. `current-jre`) while
+     * still preserving the original runtime directory name, e.g. `jre1.8.0_45.jre`.
+     */
+    @Override
+    public File getDir() {
+        File dir = super.getDir();
+        try {
+            return dir.getCanonicalFile();
+        } catch (IOException e) {
+            return dir;
+        }
+    }
+
+    private void detectType() {
+        boolean isJDK = new File(getDir(), "jre").isDirectory();
+        
+        if (isJDK) {
+            appendIncludes(new String[] {
+                    "jre/",
+            });
+            appendExcludes(new String[] {
+                    "bin/",
+                    "jre/bin/",
+                    "jre/lib/deploy/",
+                    "jre/lib/deploy.jar",
+                    "jre/lib/javaws.jar",
+                    "jre/lib/libdeploy.dylib",
+                    "jre/lib/libnpjp2.dylib",
+                    "jre/lib/plugin.jar",
+                    "jre/lib/security/javaws.policy"
+                });
+        } else {
+            appendExcludes(new String[] {
+                    "bin/",
+            });
+        }
+    }
+
+    void copyTo(File targetDir) throws IOException {
+        detectType();
+        
+        File runtimeHomeDirectory = getDir();
+        File runtimeContentsDirectory = runtimeHomeDirectory.getParentFile();
+        File runtimeDirectory = runtimeContentsDirectory.getParentFile();
+
+        // Create root plug-in directory
+        File pluginDirectory = new File(targetDir, runtimeDirectory.getName());
+        pluginDirectory.mkdir();
+
+        // Create Contents directory
+        File pluginContentsDirectory = new File(pluginDirectory, runtimeContentsDirectory.getName());
+        pluginContentsDirectory.mkdir();
+
+        // Copy MacOS directory
+        File runtimeMacOSDirectory = new File(runtimeContentsDirectory, "MacOS");
+        AppBundlerTask.copy(runtimeMacOSDirectory, new File(pluginContentsDirectory, runtimeMacOSDirectory.getName()));
+
+
+        // Copy Info.plist file
+        File runtimeInfoPlistFile = new File(runtimeContentsDirectory, "Info.plist");
+        AppBundlerTask.copy(runtimeInfoPlistFile, new File(pluginContentsDirectory, runtimeInfoPlistFile.getName()));
+
+        // Copy included contents of Home directory
+        File pluginHomeDirectory = new File(pluginContentsDirectory, runtimeHomeDirectory.getName());
+
+        DirectoryScanner directoryScanner = getDirectoryScanner(getProject());
+        String[] includedFiles = directoryScanner.getIncludedFiles();
+
+        for (int i = 0; i < includedFiles.length; i++) {
+            String includedFile = includedFiles[i];
+            File source = new File(runtimeHomeDirectory, includedFile);
+            File destination = new File(pluginHomeDirectory, includedFile);
+            AppBundlerTask.copy(source, destination);
+        }
+    }
+}

--- a/build.xml
+++ b/build.xml
@@ -69,16 +69,9 @@ questions.
             <isset property="env.JAVA_HOME"/>
         </condition>
 
-        <pathconvert property="osx.sdk.dir">
-            <first>
-                <sort>
-                    <dirset dir="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs" includes="*" />
-                    <reverse>
-                        <date />
-                    </reverse>
-                </sort>
-            </first>
-        </pathconvert>
+        <exec executable="xcrun" outputproperty="osx.sdk.dir">
+            <arg value="--show-sdk-path" />
+        </exec>
 
         <exec executable="${cc}" failonerror="true">
             <arg line="${arch64} ${arch32}"/>

--- a/build.xml
+++ b/build.xml
@@ -69,6 +69,17 @@ questions.
             <isset property="env.JAVA_HOME"/>
         </condition>
 
+        <pathconvert property="osx.sdk.dir">
+            <first>
+                <sort>
+                    <dirset dir="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs" includes="*" />
+                    <reverse>
+                        <date />
+                    </reverse>
+                </sort>
+            </first>
+        </pathconvert>
+
         <exec executable="${cc}" failonerror="true">
             <arg line="${arch64} ${arch32}"/>
             <arg value="-I"/>
@@ -83,7 +94,7 @@ questions.
             <arg value="-F"/>
             <arg value="${javahome}/../.."/>
             <arg value="-isysroot"/>
-            <arg value="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.8.sdk"/>
+            <arg value="${osx.sdk.dir}"/>
             <arg value="-mmacosx-version-min=10.7"/> 
             <arg value="appbundler/native/main.m"/>
         </exec>

--- a/build.xml
+++ b/build.xml
@@ -69,7 +69,7 @@ questions.
             <isset property="env.JAVA_HOME"/>
         </condition>
 
-        <exec executable="${cc}">
+        <exec executable="${cc}" failonerror="true">
             <arg line="${arch64} ${arch32}"/>
             <arg value="-I"/>
             <arg value="${javahome}/include"/>


### PR DESCRIPTION
Our fork of the [appbundler](https://bitbucket.org/infinitekind/appbundler) project used to bundle Insight was based on a commit where the build was only possible on OS X 10.8. Since this platform is now outdated in our infrastructure, we could no longer patch and release a new version of ome/appbundler if needed.

This PR:
- ports the latest changes included in the appbundler mainline (converting the Mercurial repo into Git via https://github.com/frej/fast-export like the first time) notable the support for more recent versions of OS X
- activates Travis for this repository to test the package compilation (OS X 10.9.5). A green build should validate the OS X support added in the mainline.

/cc @kennethgillen @joshmoore @jburel 
