### PR TITLE
Workaround for Java 9

### DIFF
--- a/appbundler/native/main.m
+++ b/appbundler/native/main.m
@@ -627,6 +627,12 @@ int extractMajorVersion (NSString *vstring)
 {
     if (vstring == nil) { return 0; }
 
+    // Workaround for Java 9 (since Java 9 version string does not start with
+    // 1. any longer)
+    if ([vstring characterAtIndex:(NSUInteger)1] == '9') {
+        return 9;
+    }
+
 //  Expecting either a java version of form 1.X.Y_ZZ or jkd1.X.Y_ZZ.
 //  Strip off everything at start up to and including the "1."
     NSUInteger vstart = [vstring rangeOfString:@"1."].location;


### PR DESCRIPTION
From Java 9 on the version string does not start with `1.x` any longer. This breaks the OSX builds (can't find JVM). This PR adds a workaround for the issue.

Test:
- Build appbundler with this PR using `ant`
- Replace the `appbundler-1.0.0.jar` in your local maven repository
- Run an OMERO `release-clients` build
- Test the OSX insight build on OSX having Java 9 installed *

*) The only way I got Java 9 on my Mac (10.11.6) working, was removing all JVM under `/Library/Java/JavaVirtualMachines/`, then installing the Oracle Java 9 SDK. Note: `./build.py` doesn't work with Java 9. So you have to build the OMERO clients with Java 8 first. Reverting back to Java 8 works the same way, clear out `/Library/Java/JavaVirtualMachines/`, then install Java 8 again.

